### PR TITLE
Adding a makefile to allow locals to easily run coding and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+include .env
+
+up:
+	docker-compose up -d
+down:
+	docker-compose down
+stop:
+	docker-compose stop
+ally:
+	@echo "Running Ally checks on the local network"
+	docker run --rm --network="solutioning-exercise_default" frvge/pa11y http://apache/
+phpcs:
+	@echo "Running coding standards on custom code"
+	docker-compose run --rm php docroot/vendor/bin/phpcs --standard=docroot/vendor/drupal/coder/coder_sniffer/Drupal docroot/modules/custom --ignore=*.min.js --ignore=*.min.css
+
+phpcbf:
+	@echo "Beautifying custom code"
+	docker-compose run --rm php docroot/vendor/bin/phpcbf --standard=docroot/vendor/drupal/coder/coder_sniffer/Drupal docroot/modules/custom --ignore=*.min.js --ignore=*.min.css
+
+reset:
+	@echo "Dropping all tables. Drupal might not be installed, ignore errors."
+	-${DC_DRUPAL} database:drop -y
+	@echo "Stopping Docker so composer packages can be removed without sharing"
+	make stop
+	@echo "Removing all composer packages"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ phpcs:
 phpcbf:
 	@echo "Beautifying custom code"
 	docker-compose run --rm php docroot/vendor/bin/phpcbf --standard=docroot/vendor/drupal/coder/coder_sniffer/Drupal docroot/modules/custom --ignore=*.min.js --ignore=*.min.css
-
+codeck:
+	@echo "Running code standards, beautifying, and running ally checks"
+	make ally
+	make phpcbf
+	make phpcs
 reset:
 	@echo "Dropping all tables. Drupal might not be installed, ignore errors."
 	-${DC_DRUPAL} database:drop -y


### PR DESCRIPTION
Adds the following make commands so developers can run the following:
* make phpcbf // linter and code fixer for easier lower hanging fruit.
* make phpcs //linter, and reports for unfixable stuff.
* make ally //runs 508 locally
* make codeck // runs all of the above in succession 

Fixes #36 